### PR TITLE
Ban specifications without an audience.

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -377,6 +377,12 @@ Group Participants who have agreed to the
 <a href=https://www.w3.org/community/about/agreements/cla/>W3C Community
 Contributor License Agreement (CLA)</a>.
 
+<p>The Community Group will not publish a <a
+href="https://www.w3.org/community/reports/">specification</a> unless at least
+two organizations have volunteered to provide <a
+href="https://www.w3.org/2019/Process-20190301/#implementation-experience">implementation
+experience</a>.</p>
+
 <p class=note>This group’s <a href=#process>process</a>,
 asynchronous <a href=#work-mode>work mode</a>, and
 efficient <a href=#decisions>decision policy</a> are based on those of


### PR DESCRIPTION
With reference to the W3C Process's requirement for implementation experience.


I think this satisfies Maciej's request. What do you think?